### PR TITLE
Fix for opscode-push-client breaks in AIX environment with error uninitialised constant ZMQ::DONTWAIT

### DIFF
--- a/ext/zmq/rbzmq.c
+++ b/ext/zmq/rbzmq.c
@@ -1006,6 +1006,7 @@ void Init_zmq ()
     rb_define_const (zmq_module, "LINGER", INT2NUM (ZMQ_LINGER));
     rb_define_const (zmq_module, "RCVHWM", INT2NUM (ZMQ_RCVHWM));
     rb_define_const (zmq_module, "SNDHWM", INT2NUM (ZMQ_SNDHWM));
+    rb_define_const (zmq_module, "DONTWAIT", INT2NUM (ZMQ_DONTWAIT));
     rb_define_const (zmq_module, "CURVE_SERVERKEY", INT2NUM (ZMQ_CURVE_SERVERKEY));
     rb_define_const (zmq_module, "CURVE_PUBLICKEY", INT2NUM (ZMQ_CURVE_PUBLICKEY));
     rb_define_const (zmq_module, "CURVE_SECRETKEY", INT2NUM (ZMQ_CURVE_SECRETKEY));


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>
opscode-pushy-client fails on the AIX as mentioned here https://github.com/chef/opscode-pushy-client/issues/162.

Adding fix which has been suggested here https://github.com/chef/opscode-pushy-client/issues/162#issuecomment-427026766 to fix the uninitialized constant ZMQ::DONTWAIT error.

This changes still needs to be tested on the AIX environment.